### PR TITLE
Fix for ansible roles

### DIFF
--- a/ansible-roles/ansible.cfg
+++ b/ansible-roles/ansible.cfg
@@ -4,3 +4,4 @@ deprecation_warnings=False
 nocows = 1
 duplicate_dict_key=ignore
 action_warnings=False
+host_key_checking = False

--- a/ansible-roles/roles/webserver/defaults/main.yml
+++ b/ansible-roles/roles/webserver/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for webserver
-nginx_version: 1.18.0-0ubuntu1.3
+nginx_version: 1.18.0*
 nginx_custom_directory: /var/www/example_domain


### PR DESCRIPTION
## Problems

- Issue with host_key_verification during `main_playbook.yml` file run via Ansible
- Issue with `Install Nginx to version 1.18.0-0ubuntu1.3` task. No installation candidate is found by `apt` module

## Changes

- Disabled host_key_verification
- Changed Nginx version to **1.18.0***

## Screenshots

### Host key verification error:
![](https://i.imgur.com/EdSk9Qw.png)

### Nginx installation error:
![](https://i.imgur.com/tLJg3y9.png)

## Testing

I tested the changes with:
- Vagrant 2.3.4
- Ansible 2.9.6

## Feedback

Please let me know if there's anything else you'd like me to address or if there are any changes you'd like me to make. I'm open to suggestions!
